### PR TITLE
Imu broadcaster support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,27 @@
+name: Build main
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    container:
+      image: osrf/ros:humble-desktop
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+      fail-fast: false
+    steps:
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y wget python3-vcstool python3-colcon-coveragepy-result
+      - name: build and test
+        uses: ros-tooling/action-ros-ci@0.3.5
+        with:
+          target-ros2-distro: humble
+          skip-tests: true

--- a/skratch_bringup/config/skratch_controllers.yml
+++ b/skratch_bringup/config/skratch_controllers.yml
@@ -7,3 +7,36 @@
 
       joint_state_broadcaster:
         type: joint_state_broadcaster/JointStateBroadcaster
+
+      front_left_wheel_imu:
+        type: imu_sensor_broadcaster/IMUSensorBroadcaster
+
+      front_right_wheel_imu:
+        type: imu_sensor_broadcaster/IMUSensorBroadcaster
+
+      rear_left_wheel_imu:
+        type: imu_sensor_broadcaster/IMUSensorBroadcaster
+
+      rear_right_wheel_imu:
+        type: imu_sensor_broadcaster/IMUSensorBroadcaster
+
+/**:
+  front_left_wheel_imu:
+    ros__parameters:
+      sensor_name: front_left_wheel_imu # this needs to match with `<sensor name="yolo"/> in the `<ros2_control>` tag
+      frame_id: front_left_wheel_imu_link
+
+  front_right_wheel_imu:
+    ros__parameters:
+      sensor_name: front_right_wheel_imu # this needs to match with `<sensor name="yolo"/> in the `<ros2_control>` tag
+      frame_id: front_right_wheel_imu_link
+
+  rear_left_wheel_imu:
+    ros__parameters:
+      sensor_name: rear_left_wheel_imu # this needs to match with `<sensor name="yolo"/> in the `<ros2_control>` tag
+      frame_id: rear_left_wheel_imu_link
+
+  rear_right_wheel_imu:
+    ros__parameters:
+      sensor_name: rear_right_wheel_imu # this needs to match with `<sensor name="yolo"/> in the `<ros2_control>` tag
+      frame_id: rear_right_wheel_imu_link

--- a/skratch_bringup/launch/robot.launch.py
+++ b/skratch_bringup/launch/robot.launch.py
@@ -144,7 +144,11 @@ def launch_setup(context) -> list[LaunchDescriptionEntity]:
                 executable="spawner",
                 arguments=[
                     "-p", controllers_path_performed,
-                    "joint_state_broadcaster",  # ???? check if we need this
+                    "joint_state_broadcaster",
+                    "front_left_wheel_imu",
+                    "front_right_wheel_imu",
+                    "rear_left_wheel_imu",
+                    "rear_right_wheel_imu"
                 ],
             )
         ],

--- a/skratch_bringup/launch/robot.launch.py
+++ b/skratch_bringup/launch/robot.launch.py
@@ -174,9 +174,13 @@ def launch_setup(context) -> list[LaunchDescriptionEntity]:
                 executable="spawner",
                 arguments=[
                     "-p", controllers_path_performed,
-                    "joint_state_broadcaster", 
+                    "joint_state_broadcaster",
+                    "front_left_wheel_imu",
+                    "front_right_wheel_imu",
+                    "rear_left_wheel_imu",
+                    "rear_right_wheel_imu"
                 ],
-            )
+            ),
         ],
         condition=LaunchConfigurationEquals("system", "gazebo")
     )

--- a/skratch_bringup/package.xml
+++ b/skratch_bringup/package.xml
@@ -17,6 +17,8 @@
   <exec_depend>ros2_control</exec_depend>
   <exec_depend>ros2_controllers</exec_depend>
   <exec_depend>gazebo_ros2_control</exec_depend>
+  <exec_depend>imu_sensor_broadcaster</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   
   <!-- this APT key just works for humble (see gz_ros2_control github repo for more details) -->
   <!--https://github.com/ros-controls/gz_ros2_control -->


### PR DESCRIPTION
this PR adds imu support, in order to make the simulation as similar as possible to the physical robot, since each “kelo drive”/“smart wheel” has an integrated IMU.
- [x] Gazebo "Classic"
- [x] Gazebo Fortress (the "new" Gazebo)

this PR depends on https://github.com/RoBonn-Systems/skratch_description/pull/2 on the `skratch_description`. 