### PR TITLE
fix parameters not found in parameter file for joint-state-broadcaster

### DIFF
--- a/skratch_bringup/config/skratch_controllers.yml
+++ b/skratch_bringup/config/skratch_controllers.yml
@@ -1,7 +1,6 @@
 /**:
   controller_manager:
     ros__parameters:
-      __ns: skratch
       update_rate: 100  # Hz
       use_sim_time: true
 

--- a/skratch_bringup/launch/robot.launch.py
+++ b/skratch_bringup/launch/robot.launch.py
@@ -142,9 +142,13 @@ def launch_setup(context) -> list[LaunchDescriptionEntity]:
             Node(
                 package="controller_manager",
                 executable="spawner",
+                arguments=["joint_state_broadcaster"],
+            ),
+            Node(
+                package="controller_manager",
+                executable="spawner",
                 arguments=[
                     "-p", controllers_path_performed,
-                    "joint_state_broadcaster",
                     "front_left_wheel_imu",
                     "front_right_wheel_imu",
                     "rear_left_wheel_imu",
@@ -177,9 +181,13 @@ def launch_setup(context) -> list[LaunchDescriptionEntity]:
             Node(
                 package="controller_manager",
                 executable="spawner",
+                arguments=["joint_state_broadcaster"],
+            ),
+            Node(
+                package="controller_manager",
+                executable="spawner",
                 arguments=[
                     "-p", controllers_path_performed,
-                    "joint_state_broadcaster",
                     "front_left_wheel_imu",
                     "front_right_wheel_imu",
                     "rear_left_wheel_imu",

--- a/skratch_bringup/launch/robot.launch.py
+++ b/skratch_bringup/launch/robot.launch.py
@@ -103,15 +103,26 @@ def launch_setup(context) -> list[LaunchDescriptionEntity]:
         ]
     )
 
-
-    # controller_manager
-    controller_manager = Node(
-        package="controller_manager",
-        executable="spawner",
-        arguments=[
-            "-p", controllers_path_performed,
-            "joint_state_broadcaster", 
-        ],
+    controllers = GroupAction(
+        actions=[
+            Node(
+                package="controller_manager",
+                executable="spawner",
+                arguments=["joint_state_broadcaster"],
+            ),
+            Node(
+                package="controller_manager",
+                executable="spawner",
+                arguments=[
+                    "-p", controllers_path_performed,
+                    "front_left_wheel_imu",
+                    "front_right_wheel_imu",
+                    "rear_left_wheel_imu",
+                    "rear_right_wheel_imu",
+                    "base_velocity_controller"
+                ],
+            ),
+        ]
     )
 
     gz_spawn = GroupAction(
@@ -139,23 +150,6 @@ def launch_setup(context) -> list[LaunchDescriptionEntity]:
                 ],
                 output='both',
             ),
-            Node(
-                package="controller_manager",
-                executable="spawner",
-                arguments=["joint_state_broadcaster"],
-            ),
-            Node(
-                package="controller_manager",
-                executable="spawner",
-                arguments=[
-                    "-p", controllers_path_performed,
-                    "front_left_wheel_imu",
-                    "front_right_wheel_imu",
-                    "rear_left_wheel_imu",
-                    "rear_right_wheel_imu",
-                    "base_velocity_controller"
-                ],
-            )
         ],
         condition=LaunchConfigurationEquals("system", "gz")
     )
@@ -177,23 +171,6 @@ def launch_setup(context) -> list[LaunchDescriptionEntity]:
                     "-y", LaunchConfiguration("y"),
                     "-z", LaunchConfiguration("z"),
                     "-entity", LaunchConfiguration("robot_name")]
-            ),
-            Node(
-                package="controller_manager",
-                executable="spawner",
-                arguments=["joint_state_broadcaster"],
-            ),
-            Node(
-                package="controller_manager",
-                executable="spawner",
-                arguments=[
-                    "-p", controllers_path_performed,
-                    "front_left_wheel_imu",
-                    "front_right_wheel_imu",
-                    "rear_left_wheel_imu",
-                    "rear_right_wheel_imu",
-                    "base_velocity_controller"
-                ],
             ),
         ],
         condition=LaunchConfigurationEquals("system", "gazebo")
@@ -218,6 +195,7 @@ def launch_setup(context) -> list[LaunchDescriptionEntity]:
         PushRosNamespace(LaunchConfiguration("robot_name")), # this help to add namespace to all entities
         robot_state_publisher,
         gazebo_spawn_and_control,
+        controllers,
         gz_spawn,
         rviz
     ]


### PR DESCRIPTION
After a fresh install of the system we get a `fix parameters not found in parameter file` FATAL error (see output).

the sections related with error are:
- [for gazebo "ignition"](https://github.com/RoBonn-Systems/skratch_ros2/blob/02ac03e988abb04a54bcbd0938cdc1e26584eaf2/skratch_bringup/launch/robot.launch.py#L142-L154)
- [for gazebo classic](https://github.com/RoBonn-Systems/skratch_ros2/blob/02ac03e988abb04a54bcbd0938cdc1e26584eaf2/skratch_bringup/launch/robot.launch.py#L177-L189)

This may be caused by changes in `ros2_control` and the mechanisms that have to do with the spawner, but I don't know exactly which commit introduces the breaking changes. See [history of commits](https://github.com/ros-controls/ros2_control/commits/humble/controller_manager/controller_manager/spawner.py), but I did no further research to find out exactly which commit breaks our `joint-state-broadcaster` launch.

**Solution**: launch the `joint-state-broadcaster` separately to prevent the `spawner` (internal) implementation from looking for a controller associated with `joint-state-broadcaster` (that seems to be the problem).

```
[spawner-5] [INFO] [1733924605.478793145] [skratch.spawner_joint_state_broadcaster]: Setting controller param "params_file" to "/home/lacoro/lss_ws/install_clang/skratch_bringup/share/skratch_bringup/config/skratch_controllers.yml" for joint_state_broadcaster
[spawner-5] [FATAL] [1733924605.487189335] [skratch.spawner_joint_state_broadcaster]: Controller : /skratch/joint_state_broadcaster parameters not found in parameter file : /home/lacoro/lss_ws/install_clang/skratch_bringup/share/skratch_bringup/config/skratch_controllers.yml
[INFO] [spawn_entity.py-4]: process has finished cleanly [pid 3468]
[spawner-5] Traceback (most recent call last):
[spawner-5]   File "/opt/ros/humble/lib/controller_manager/spawner", line 33, in <module>
[spawner-5]     sys.exit(load_entry_point('controller-manager==2.44.0', 'console_scripts', 'spawner')())
[spawner-5]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/controller_manager/spawner.py", line 186, in main
[spawner-5]     if not set_controller_parameters_from_param_file(
[spawner-5]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/controller_manager/controller_manager_services.py", line 350, in set_controller_parameters_from_param_file
[spawner-5]     controller_type = get_parameter_from_param_file(
[spawner-5]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/controller_manager/controller_manager_services.py", line 294, in get_parameter_from_param_file
[spawner-5]     if parameter_name in controller_param_dict[ROS_PARAMS_KEY]:
[spawner-5] TypeError: 'NoneType' object is not subscriptable
[ERROR] [spawner-5]: process has died [pid 3471, exit code 1, cmd '/opt/ros/humble/lib/controller_manager/spawner -p /home/lacoro/lss_ws/install_clang/skratch_bringup/share/skratch_bringup/config/skratch_controllers.yml joint_state_broadcaster front_left_wheel_imu front_right_wheel_imu rear_left_wheel_imu rear_right_wheel_imu base_velocity_controller --ros-args -r __ns:=/skratch'].
```